### PR TITLE
Add ARM64 support to Travis-CI and Add ARM64 architecture to build-all for releasing ARM64 binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 
 dist: trusty
 sudo: required
+arch:
+  - amd64
+  - arm64
 
 env:
   global:

--- a/scripts/build-all
+++ b/scripts/build-all
@@ -21,6 +21,7 @@ build() {
 
 build darwin amd64 osx
 build linux amd64 linux64
+build linux arm64 linux_arm64
 build linux 386 linux32
 build windows amd64 win64
 build windows 386 win32


### PR DESCRIPTION
1. Added ARM64 architecture to .travis.yml file.
2. Added ARM64 architecture to build-all for releasing ARM64 ascli binary.

Signed-off-by: odidev <odidev@puresoftware.com>