### PR TITLE
fix(cfclient): Correctly forward `--skip-ssl-validation`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           readonly branch_name="bump-app-autoscaler-cli-plugin-to-${NEW_TAG}"
           git switch --create="${branch_name}"
           git add .
-          git commit --message="Bump app-autoscaler-cli-plugin to ${NEW_TAG}\n\nThis is an automated commit to bump app-autoscaler-cli-plugin to [${NEW_TAG}](https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/tag/${NEW_TAG})."
+          git commit --message="Bump app-autoscaler-cli-plugin to ${NEW_TAG}" --message="This is an automated commit to bump app-autoscaler-cli-plugin to [${NEW_TAG}](https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/tag/${NEW_TAG})."
           git push origin "${branch_name}"
           # gh pr create --fill --head "origin:${branch_name}" --base main # This currently not working due to https://github.com/cli/cli/issues/2691
           popd

--- a/api/cf_api_client.go
+++ b/api/cf_api_client.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	cf_client "github.com/cloudfoundry/go-cfclient/v3/client"
+	cf_client_config "github.com/cloudfoundry/go-cfclient/v3/config"
+
+	"code.cloudfoundry.org/app-autoscaler-cli-plugin/ui"
+)
+
+type CFAPIClient struct {
+	client *cf_client.Client
+}
+
+func NewCFAPIClient(ccAPIEndpoint *url.URL, authToken string, skipTLSValidation bool) (*CFAPIClient, error) {
+	// A refresh token is not provided by the CF CLI Plugin API and is not required as
+	// "AccessToken() now provides a refreshed o-auth token.",
+	// see https://github.com/cloudfoundry/cli/blob/main/plugin/plugin_examples/CHANGELOG.md#changes-in-v614
+	refreshToken := ""
+
+	cfClientConfigOptions := []cf_client_config.Option{
+		cf_client_config.Token(authToken, refreshToken),
+	}
+
+	if skipTLSValidation {
+		cfClientConfigOptions = append(cfClientConfigOptions, cf_client_config.SkipTLSValidation())
+	}
+
+	cfg, err := cf_client_config.New(ccAPIEndpoint.String(), cfClientConfigOptions...)
+	if err != nil {
+		return nil, err
+	}
+	cf, err := cf_client.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &CFAPIClient{client: cf}, nil
+}
+
+func (client *CFAPIClient) GetAppGUID(appName string, currentSpaceGUID string) (string, error) {
+	appFilter := &cf_client.AppListOptions{
+		Names:      cf_client.Filter{Values: []string{appName}},
+		SpaceGUIDs: cf_client.Filter{Values: []string{currentSpaceGUID}},
+	}
+	apps, err := client.client.Applications.ListAll(context.Background(), appFilter)
+	if err != nil {
+		return "", err
+	}
+
+	if len(apps) == 0 {
+		return "", fmt.Errorf(ui.NoApp, appName)
+	}
+
+	app := apps[0]
+	return app.GUID, nil
+}


### PR DESCRIPTION
# Issue

When targetting CF foundation with an invalid cert the plugin would not
work, even though the CLI had been logged in using
`--skip-ssl-validation`

# Fix

Correctly forward the option to the CF API client

# Note

Factored CF API client for clearer control flow.

- fix(relase): Correctly create commit message.
