### PR TITLE
chore(autoscaling-policy): Displays the Configuration Information

### DIFF
--- a/api/apihelper.go
+++ b/api/apihelper.go
@@ -266,7 +266,7 @@ func (helper *APIHelper) CreatePolicy(data interface{}) error {
 	}
 	defer resp.Body.Close()
 
-	raw, err := ioutil.ReadAll(resp.Body)
+	raw, err := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 
@@ -303,7 +303,7 @@ func (helper *APIHelper) DeletePolicy() error {
 	}
 	defer resp.Body.Close()
 
-	raw, err := ioutil.ReadAll(resp.Body)
+	raw, err := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		var errorMsg string
 		switch resp.StatusCode {
@@ -358,7 +358,7 @@ func (helper *APIHelper) GetAggregatedMetrics(metricName string, startTime, endT
 	}
 	defer resp.Body.Close()
 
-	raw, err := ioutil.ReadAll(resp.Body)
+	raw, err := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		var errorMsg string
 		switch resp.StatusCode {
@@ -424,7 +424,7 @@ func (helper *APIHelper) GetHistory(startTime, endTime int64, asc bool, page uin
 	}
 	defer resp.Body.Close()
 
-	raw, err := ioutil.ReadAll(resp.Body)
+	raw, err := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		var errorMsg string
 		switch resp.StatusCode {

--- a/commands/retrieve_history.go
+++ b/commands/retrieve_history.go
@@ -105,7 +105,7 @@ func RetrieveHistory(cliConnection api.Connection, appName string, startTime, en
 		data       [][]string
 	)
 
-	for true {
+	for {
 		next, data, err = apihelper.GetHistory(startTime, endTime, asc, page)
 		if err != nil {
 			return err

--- a/devbox.lock
+++ b/devbox.lock
@@ -309,7 +309,7 @@
     },
     "python@latest": {
       "last_modified": "2024-08-14T11:41:26Z",
-      "plugin_version": "0.0.3",
+      "plugin_version": "0.0.4",
       "resolved": "github:NixOS/nixpkgs/0cb2fd7c59fed0cd82ef858cbcbdb552b9a33465#python3",
       "source": "devbox-search",
       "version": "3.12.4",

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ var BuildVcsId string
 var BuildVcsIdDate string
 
 func (as *AutoScaler) GetMetadata() plugin.PluginMetadata {
-	version := getVetsion()
+	version := getVersion()
 
 	return plugin.PluginMetadata{
 		Name:    "AutoScaler",
@@ -114,7 +114,7 @@ OPTIONS:
 	}
 }
 
-func getVetsion() plugin.VersionType {
+func getVersion() plugin.VersionType {
 	// We set a default version 0.0.0, and then we try to parse the version from the build flags
 	// errors are ignored, as we will use the default version in case of errors
 	version := plugin.VersionType{Major: 0, Minor: 0, Build: 0}
@@ -129,14 +129,14 @@ func main() {
 
 	args := os.Args[1:]
 	if len(args) == 0 {
-		version := getVetsion()
+		version := getVersion()
 		fmt.Printf("Upstream Version: %d.%d.%d\n", version.Major, version.Minor, version.Build)
 		fmt.Println("Build Prerelease: ", BuildPrerelease)
 		fmt.Println("Build Version: ", BuildMeta)
 		fmt.Println("Build Date: ", BuildDate)
 		fmt.Println("VCS Url:", BuildVcsUrl)
 		fmt.Println("VCS Identifier: ", BuildVcsId)
-		fmt.Println("VCS Identififer Date: ", BuildVcsIdDate)
+		fmt.Println("VCS Identifier Date: ", BuildVcsIdDate)
 	}
 	plugin.Start(new(AutoScaler))
 }

--- a/models/models.go
+++ b/models/models.go
@@ -4,11 +4,20 @@ type ScalingType int
 
 type ScalingStatus int
 
+type Configuration struct {
+	CustomMetrics struct {
+		MetricSubmissionStrategy struct {
+			AllowFrom string `json:"allow_from"`
+		} `json:"metric_submission_strategy"`
+	} `json:"custom_metrics"`
+}
+
 type ScalingPolicy struct {
-	InstanceMin  int               `json:"instance_min_count"`
-	InstanceMax  int               `json:"instance_max_count"`
-	ScalingRules []*ScalingRule    `json:"scaling_rules,omitempty"`
-	Schedules    *ScalingSchedules `json:"schedules,omitempty"`
+	InstanceMin   int               `json:"instance_min_count"`
+	InstanceMax   int               `json:"instance_max_count"`
+	ScalingRules  []*ScalingRule    `json:"scaling_rules,omitempty"`
+	Schedules     *ScalingSchedules `json:"schedules,omitempty"`
+	Configuration *Configuration    `json:"configuration,omitempty"`
 }
 
 type ScalingRule struct {

--- a/ui/message.go
+++ b/ui/message.go
@@ -12,8 +12,8 @@ const (
 	SetAPIEndpoint     = "Setting AutoScaler api endpoint to %s..."
 	UnsetAPIEndpoint   = "Unsetting AutoScaler api endpoint."
 	InvalidAPIEndpoint = "Invalid AutoScaler API endpoint : %s"
-	InvalidSSLCerts    = "Issue connnecting to %s: %s\nTIP: Use --skip-ssl-validation to continue with an insecure API endpoint."
-	InconsistentDomain = "Failed to set AutoScaler domain to %s since it is inconsitent with the domain of CF API %s."
+	InvalidSSLCerts    = "Issue connecting to %s: %s\nTIP: Use --skip-ssl-validation to continue with an insecure API endpoint."
+	InconsistentDomain = "Failed to set AutoScaler domain to %s since it is inconsistent with the domain of CF API %s."
 
 	Unauthorized  = "Unauthorized. Failed to access AutoScaler API endpoint %s."
 	LoginRequired = "You must be logged in %s first."


### PR DESCRIPTION

Included Configuration information (introduced in [PR#3211](https://github.com/cloudfoundry/app-autoscaler-release/pull/3211)) when calling `cf autoscaling-policy <APP_NAME>`  command

**Example**


$ cf autoscaling-policy test_app
Retrieving policy for app test_app...
```json
{
	"instance_min_count": 1,
	"instance_max_count": 4,
	"scaling_rules": [
		{
			"metric_type": "test_metric",
			"breach_duration_secs": 60,
			"threshold": 201,
			"operator": ">=",
			"cool_down_secs": 60,
			"adjustment": "+1"
		},
		{
			"metric_type": "test_metric",
			"breach_duration_secs": 60,
			"threshold": 100,
			"operator": "<=",
			"cool_down_secs": 60,
			"adjustment": "-1"
		}
	],
	"configuration": {
		"custom_metrics": {
			"metric_submission_strategy": {
				"allow_from": "bound_app"
			}
		}
	}
}
```