### PR TITLE
chore(devbox): Replace `gh` package

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,12 +1,12 @@
 {
   "packages": {
-    "goimports-reviser":    "3.9.1",
-    "golangci-lint":        "2.1.6",
-    "python":               "3.13.3",
-    "pipenv":               "2024.4.1",
-    "github-cli":           "2.23.0",
-    "ginkgo":               "2.23.4",
-    "gnumake":              "4.4.1",
-    "go":                   "1.24.3"
+    "goimports-reviser": "3.9.1",
+    "golangci-lint":     "2.1.6",
+    "python":            "3.13.3",
+    "pipenv":            "2024.4.1",
+    "ginkgo":            "2.23.4",
+    "gnumake":           "4.4.1",
+    "go":                "1.24.3",
+    "gh":                "latest"
   }
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,6 +1,54 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "gh@latest": {
+      "last_modified": "2025-08-01T06:30:45Z",
+      "resolved": "github:NixOS/nixpkgs/a7822a17050fedda63794775b9090880c8214290#gh",
+      "source": "devbox-search",
+      "version": "2.76.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/03sfs0afrm8j3gwrdnj324zw7yg959bd-gh-2.76.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/03sfs0afrm8j3gwrdnj324zw7yg959bd-gh-2.76.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/pc1gkqbg0di68fpxqg5dxz0dvdvldf1a-gh-2.76.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/pc1gkqbg0di68fpxqg5dxz0dvdvldf1a-gh-2.76.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6sxip9nc0v8hsdyzjdhmj1qsxr3m4p6i-gh-2.76.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6sxip9nc0v8hsdyzjdhmj1qsxr3m4p6i-gh-2.76.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/72ihgykz0r9a5s3iqzrcm9x2rnp3sjap-gh-2.76.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/72ihgykz0r9a5s3iqzrcm9x2rnp3sjap-gh-2.76.2"
+        }
+      }
+    },
     "ginkgo@2.23.4": {
       "last_modified": "2025-05-16T20:19:48Z",
       "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#ginkgo",
@@ -48,12 +96,6 @@
           "store_path": "/nix/store/szgq7mx93ihzlhv8jxb9fcb2l5ad22fy-ginkgo-2.23.4"
         }
       }
-    },
-    "github-cli@2.23.0": {
-      "last_modified": "2023-02-24T09:01:09Z",
-      "resolved": "github:NixOS/nixpkgs/7d0ed7f2e5aea07ab22ccb338d27fbe347ed2f11#github-cli",
-      "source": "devbox-search",
-      "version": "2.23.0"
     },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
       "last_modified": "2025-05-12T23:16:24Z",


### PR DESCRIPTION
# Issue

The devbox contained an outdate package `github-cli` which does no
longer exist in current NixOS version causing errors when trying to
update packages.

# Fix

Replace with the new `gh` package.
